### PR TITLE
Use maplebacon.org as the website's main domain name

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+maplebacon.org


### PR DESCRIPTION
Any ubcctf.github.io links will be automatically redirected to maplebacon.org. DNS settings currently point to ubcctf.github.io, so the url change should take place rather quickly. If this doesn't actually work: then maybe CNAME settings can only be changed from the Github Pages settings (and someone with owner permissions will have to change it).

this likely fixes our tls issues on ctf.maplebacon.org