### PR TITLE
Add CTF link to header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,6 +37,7 @@
           {% for p in pages %}
           <a href="/{{ p }}"{% if page.name contains p %} class="active"{% endif %}>{{ p }}</a>
           {% endfor %}
+          <a href="https://ctf.maplebacon.org" >maple&nbsp;ctf&nbsp;2022</a>
         </nav>
         <div class="logo">
           <a href="/">


### PR DESCRIPTION
This PR adds a link to the CTF page in the header. The actual landing page is PRed in ubcctf/maple-ctf-landing-page#1.